### PR TITLE
Make extensions optional in JS

### DIFF
--- a/dropboxchooser_field/static/js/dropboxchooser_field/chooser.js
+++ b/dropboxchooser_field/static/js/dropboxchooser_field/chooser.js
@@ -16,7 +16,7 @@
         };
         
         // add extensions only if specified
-        if chooser_field.hasAttribute("data-extensions") {
+        if(chooser_field.hasAttribute("data-extensions")) {
             options['extensions'] =  chooser_field.getAttribute("data-extensions")
                 .split(" ");
         }

--- a/dropboxchooser_field/static/js/dropboxchooser_field/chooser.js
+++ b/dropboxchooser_field/static/js/dropboxchooser_field/chooser.js
@@ -9,12 +9,17 @@
 
         options = {
             linkType: "direct",
-            extensions: chooser_field.getAttribute("data-extensions").split(" "),
 
             success: function(files) {
                 chooser_field.value = files[0].link
             }
         };
+        
+        // add extensions only if specified
+        if chooser_field.hasAttribute("data-extensions") {
+            options['extensions'] =  chooser_field.getAttribute("data-extensions")
+                .split(" ");
+        }
 
         var button = Dropbox.createChooseButton(options);
         chooser_field.parentNode.insertBefore(button, chooser_field);


### PR DESCRIPTION
In the changes you made in response to issue #1, inputs without specified extensions would crash, even though the "extensions" option in the API is optional. This checks to see if any are specified before trying to fetch them.
